### PR TITLE
Makefile fix under dash

### DIFF
--- a/src/nvctrl/Makefile
+++ b/src/nvctrl/Makefile
@@ -8,6 +8,7 @@ BASENAME = nvctrl_c
 SRC = $(BASENAME).c
 OBJ = $(BUILDDIR)/lib$(BASENAME).o
 OUT = $(BUILDDIR)/lib$(BASENAME).a
+SHELL = bash
 
 .PHONY: $(BUILDDIR)
 


### PR DESCRIPTION
Makefile might use `sh`, which is dash on Debian/Ubuntu and `ar` might fail in such case