### PR TITLE
Stop limiting min and max possible fan speeds to 20% and 80%

### DIFF
--- a/src/nvctrl/lib.rs
+++ b/src/nvctrl/lib.rs
@@ -80,15 +80,7 @@ impl NvidiaControl {
     }
 
     pub fn set_fanspeed(&self, speed: i32) {
-        let true_speed: i32;
-        if speed < 20 {
-            true_speed = 20
-        } else if speed > 80 {
-            true_speed = 80
-        } else {
-            true_speed = speed
-        }
-        unsafe { nv_set_fanspeed(true_speed as c_int); }
+        unsafe { nv_set_fanspeed(speed as c_int); }
     }
 
     pub fn get_fanspeed_rpm(&self) -> i32 {


### PR DESCRIPTION
Fixes #4.

The issue was indeed with this tool, not with XNVCtrl.

This limit shouldn't exist in the first, since it limits user's capabilities even if card supports 0rpm (like my GIGABYTE GeForce GTX 1070 G1 Gaming does). Tested this patch on my card - happily stays at 0rpm until I run some really heavy game that pushes it beyond 60°C.