### PR TITLE
xorg.conf.d directory is different in modern Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ not available or you explicitly want it to be linked dynamically add
 ### Enable Coolbits (Linux only)
 
 For Linux ensure that Coolbits is enabled from your X11 server settings. To
-do so create a file named `20-nvidia.conf` within `/etc/X11/xorg.conf.d/`
-containing the following
+do so create a file named `20-nvidia.conf` within `/etc/X11/xorg.conf.d/` or
+`/usr/share/X11/xorg.conf.d/` (depends on distribution) containing the
+following
 
     Section "Device"
         Identifier "Device 0"


### PR DESCRIPTION
According to https://wiki.ubuntu.com/X/Config modern versions of Ubuntu (since 10.10) use `/usr/share/X11/xorg.conf.d` instead of mentioned `/etc/X11/xorg.conf.d/`.
I'm not sure what other distros are using, so I've just added another path as an option.