### PR TITLE
Option to prevent or stop low speed GPU fan flickering

### DIFF
--- a/src/fanflicker.rs
+++ b/src/fanflicker.rs
@@ -1,0 +1,180 @@
+use std::cmp::{max, min};
+use fanspeedcurve::FanspeedCurve;
+
+const FLICKER_TEMP_MAX: i32 = 75;
+const FLICKER_TEMP_MAX_REASON: &str = "\n        \
+below the limit speed adjustments are not instant, so the temperature might temporarily rise higher";
+
+pub struct FanFlickerRange {
+    pub minimum_allowed: i32,
+    pub fickering_starts: i32
+}
+
+pub struct FanFlickerFix {
+    range: FanFlickerRange,
+    previous_speed: i32,
+}
+
+impl FanFlickerRange {
+
+    pub fn new(
+        range: (u16, u16),
+        curve: &FanspeedCurve,
+        limits: &Option<(u16, u16)>,
+    ) -> Result<FanFlickerRange, String> {
+
+        let minimum_allowed = range.0;
+        let fickering_starts = range.1;
+
+        let errmsg = match ((minimum_allowed, fickering_starts), limits, curve.temp_x(fickering_starts)) {
+            ((m, _), _, _) if m < 1 =>
+                format!("fanflicker: `minimum` must be greater than zero"),
+            ((m, s), _, _) if m >= s =>
+                format!("fanflicker: `minimum` ({}) not less than `starts` ({})",
+                        minimum_allowed, fickering_starts),
+            (_, &Some((low, high)), _) if minimum_allowed < low || fickering_starts > high =>
+                format!("fanflicker range [{}, {}] not within general fan limits [{}, {}]",
+                        minimum_allowed, fickering_starts, low, high),
+            (_, _, Some(speed)) if speed > FLICKER_TEMP_MAX =>
+                format!("fanflicker: upper fanspeed limit of {} allows a \
+                         temperature of {}°C which exceeds the safe limit of {}°C:{}",
+                        fickering_starts, speed, FLICKER_TEMP_MAX, FLICKER_TEMP_MAX_REASON),
+            (_, _, None) =>
+                format!("fanflicker: upper fanspeed limit of {} is unreachable with the given points, \
+                        so the safe temperature limit of {}°C can not be guaranteed:{}",
+                        fickering_starts, FLICKER_TEMP_MAX, FLICKER_TEMP_MAX_REASON),
+             _ => String::new(),
+        };
+
+        if errmsg.len() > 0 {
+            return Err(errmsg);
+        }
+
+        info!("Trying to prevent fan flickering in range [{}, {}]", minimum_allowed, fickering_starts);
+
+        Ok(FanFlickerRange {
+            minimum_allowed: minimum_allowed as i32,
+            fickering_starts: fickering_starts  as i32
+        })
+    }
+}
+
+impl FanFlickerFix {
+
+    pub fn new(range: FanFlickerRange, previous_speed: i32) -> FanFlickerFix {
+        debug!("FanFlickerFix: setting previous speed to {}%", previous_speed);
+        FanFlickerFix { range, previous_speed }
+    }
+
+    pub fn minimum(&self) -> i32 {
+        self.range.minimum_allowed
+    }
+
+    /// See if the `requested` new speed might trigger fan flicker. If so, modify it, taking
+    /// the previously set speed into account.
+    /// This will only have an effect when `requested` is at or below the `fickering_starts`
+    /// value specified in `FanFlickerFix` or rpm is zero.
+    #[deny(unreachable_patterns)]
+    pub fn fix_speed(&mut self, current_rpm: i32, requested: i32) -> i32 {
+
+        let fickering_starts = self.range.fickering_starts;
+        let minimum_allowed = self.range.minimum_allowed;
+
+        //  Currently flickering on and off.
+        // TODO: history of previous attemps, maybe fickering_starts + 10 is required
+        if current_rpm == 0 {
+            self.previous_speed = fickering_starts;
+            debug!("FanFlickerFix: flicking detected (RPM: 0), setting {}%",
+                   self.previous_speed);
+            return self.previous_speed;
+        }
+
+
+        let increment = 2;
+        let decrement = 1;
+
+        /// Position relative to the flicker range.
+        #[derive(Debug)]
+        enum Pos {
+            Above(i32),
+            InRange(i32),
+            Below(i32), // i32 value only used for debug output.
+        }
+
+        /// Direction of speed change relative to previous state: increase or decrease.
+        #[derive(Debug)]
+        enum Dir {
+            Inc,
+            Dec, // also covers equality case
+        }
+
+        struct Delta {
+            from: Pos,
+            to: Pos,
+            dir: Dir,
+        }
+
+        let mk_pos = |speed: i32| -> Pos {
+            if speed < minimum_allowed {
+                Pos::Below(speed)
+            } else if speed > fickering_starts {
+                Pos::Above(speed)
+            } else {
+                Pos::InRange(speed)
+            }
+        };
+
+        let delta = Delta {
+            from : mk_pos(self.previous_speed),
+            to: mk_pos(requested),
+            dir: if requested > self.previous_speed { Dir::Inc } else { Dir::Dec }
+        };
+
+        let new_speed = match delta {
+            // Only watch over the flicker range.
+            Delta { from: _, to: Pos::Above(new), dir: _ }
+                => new,
+
+            // Should never be in or come from Below (rpm == 0 caught above), but just in case...
+            Delta { from: Pos::Below(_), to: _, dir: _ }
+                => fickering_starts,
+
+            // These from/to and direction combinations are impossible.
+            Delta { from: Pos::Above(_), to: _, dir: Dir::Inc }
+            | Delta { from: Pos::InRange(_), to: Pos::Below(_), dir: Dir::Inc }
+                => unreachable!(),
+
+            // Jumping down into the flicker range, possibly even below it.
+            Delta { from: Pos::Above(_), to: Pos::InRange(_), dir: Dir::Dec }
+            | Delta { from: Pos::Above(_), to: Pos::Below(_), dir: Dir::Dec }
+                => fickering_starts,
+
+            // Speed increases also cause this problem, so slow the speedup,
+            // sometimes leads to flickering nonetheless, not reliable.
+            // When slowing the increase the here the temperature might reach FLICKER_TEMP_MAX.
+            Delta { from: Pos::InRange(prev), to: Pos::InRange(new), dir: Dir::Inc }
+                => min(prev + increment, new),
+
+            // Lowering the speed and between minimum_allowed and fickering_starts, step one down.
+            Delta { from: Pos::InRange(prev), to: Pos::InRange(new), dir: Dir::Dec }
+                => max(prev - decrement, new),
+
+            // Lowering below the range requested.
+            Delta { from: Pos::InRange(prev), to: Pos::Below(_), dir: Dir::Dec }
+                => max(prev - decrement, minimum_allowed),
+        };
+
+        debug!("FanFlickerFix [{}, {}]: requested change from {:?} to {:?} ({}), {} {}%",
+               minimum_allowed,
+               fickering_starts,
+               delta.from,
+               delta.to,
+               if let Dir::Inc = delta.dir { "increase" } else { "decrease" },
+               if new_speed == self.previous_speed { "staying at" } else { "setting" },
+               new_speed);
+
+        self.previous_speed = new_speed;
+
+        new_speed
+    }
+}

--- a/src/fanspeedcurve.rs
+++ b/src/fanspeedcurve.rs
@@ -1,0 +1,331 @@
+#[derive(Debug, PartialEq)]
+pub struct FanspeedCurve(Vec<(u16, u16)>);
+
+const EPTS: &'static str = "not enough data points";
+const EMONO: &'static str = "not monotonically increasing";
+
+
+//         ^
+//         |                             (3) +--------------->
+//      f  |                                /
+//      a  |                               /
+//      n  |                           _.-+
+//      s  |                     (2) +`
+//      p  |
+//      e  |
+//      e  |                  +------o
+//      d  |                 /
+//         |                /
+//      %  |               /
+//         |          (1) +
+//         |
+//         +--------------------------------------------------------->
+//
+//            temperature (°C)
+//
+// Temperature (x) to fanspeed (y) curve. `speed_y` will return `None` below
+// the minimum (1). Discontinuities are possible (2), then the larger value is used.
+// For values larger than the maximum (3), the maximum is returned.
+// If quering the corresponding temperature for a given speed (`temp_x`), `None` is
+// returned both below and above the minimum or maximum fanspeed.
+
+impl FanspeedCurve {
+
+    pub fn new(points: Vec<(u16, u16)>) -> Result<FanspeedCurve, &'static str> {
+        if points.len() <= 1 {
+            Err(EPTS)
+        } else if !points.windows(2).all(|pair| pair[0].0 <= pair[1].0 && pair[0].1 <= pair[1].1) {
+            Err(EMONO)
+        } else {
+            Ok(FanspeedCurve(remove_redundant_points(points)))
+        }
+    }
+
+     pub fn minspeed(&self) -> i32 {
+        self.0.first().unwrap().1 as i32
+    }
+
+    pub fn speed_y(&self, temp_x: u16) -> Option<i32> {
+
+        let last = self.0.last().unwrap();
+        // `>=` to prevent dx = 0 and division by zero if p0/p1 have equal x values
+        if temp_x >= last.0 {
+            debug!("Temperature outside curve; setting to max");
+            return Some(last.1 as i32)
+        }
+
+        if temp_x < self.0.first().unwrap().0 {
+            return None
+        }
+
+        // `rev()` so dx is always > 0, i.e. the slope of a purely vertical
+        // point pair is never calculated because the endpoint of the previous one
+        // matched already or was handled above if this is the last pair.
+        for i in self.0.windows(2).rev() {
+            let (p0, p1) = (i[0], i[1]);
+
+            if temp_x >= p0.0 && temp_x <= p1.0 {
+                let dx = p1.0 - p0.0;
+                let dy = p1.1 - p0.1;
+
+                if dx == 0 {
+                   unreachable!();
+                }
+
+                let slope = (dy as f32) / (dx as f32);
+
+                let speed_y = (p0.1 as f32) + (((temp_x - p0.0) as f32) * slope);
+
+                return Some(speed_y as i32)
+            }
+        }
+
+        // <min and >max were previously handled
+        unreachable!()
+    }
+
+    pub fn temp_x(&self, speed_y: u16) -> Option<i32> {
+
+        let last = self.0.last().unwrap();
+        // to prevent dy = 0 and division by zero if p0/p1 have equal y values
+        if speed_y == last.1 {
+            return Some(last.0 as i32)
+        }
+
+        for i in self.0.windows(2).rev() { // `rev()`, see above
+            let (p0, p1) = (i[0], i[1]);
+
+            if speed_y >= p0.1 && speed_y <= p1.1 {
+                let dx = p1.0 - p0.0;
+                let dy = p1.1 - p0.1;
+
+                if dy == 0 {
+                   unreachable!();
+                }
+
+                let slope = (dx as f32) / (dy as f32);
+
+                let temp_x = (p0.0 as f32) + (((speed_y - p0.1) as f32) * slope);
+
+                return Some(temp_x as i32)
+            }
+        }
+
+        None
+    }
+}
+
+fn remove_redundant_points(points: Vec<(u16, u16)>) -> Vec<(u16, u16)> {
+
+    let three_identical_x_or_y_coords = |x3: &[(usize, &(u16, u16))]| -> bool {
+        ((x3[0].1).0 == (x3[1].1).0 && (x3[0].1).0 == (x3[2].1).0)
+        || ((x3[0].1).1 == (x3[1].1).1 && (x3[0].1).1 == (x3[2].1).1)
+    };
+
+    let remove_indices = points
+        .iter()
+        .enumerate()
+        .collect::<Vec<_>>()
+        .windows(3)
+        .filter_map(|x| {
+            if three_identical_x_or_y_coords(x) {
+                let index_of_middle_point = x[1].0;
+                Some(index_of_middle_point)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    points
+        .iter()
+        .enumerate()
+        .filter_map(|(index, value)| {
+            if remove_indices.iter().find(|x| **x == index).is_some() {
+                None
+            } else {
+                Some(*value)
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+#[test]
+fn test_remove_redundant_points() {
+    let p = vec![(1, 1),
+                 (2, 2), (2, 5), (2, 5),
+                 (3, 8), (3, 9), (3, 10),
+                 (4, 10),
+                 (5, 11), (6, 11), (7, 11),
+                 (8, 12)];
+
+    let q = remove_redundant_points(p);
+
+    assert_eq!(q, vec![(1, 1), (2, 2), (2, 5), (3, 8), (3, 10),
+                       (4, 10), (5, 11), (7, 11), (8, 12)]);
+
+    assert!(FanspeedCurve::new(q).is_ok());
+}
+
+#[test]
+fn test_empty() {
+    assert_eq!(FanspeedCurve::new(vec![]).err(), Some(EPTS));
+}
+
+#[test]
+fn test_dot_only() {
+    assert_eq!(FanspeedCurve::new(vec![(4, 6),]).err(), Some(EPTS));
+}
+
+#[test]
+fn test_decreasing() {
+    let down = FanspeedCurve::new(vec![(0, 10), (2, 5), (3, 1)]);
+
+    assert_eq!(down.err(), Some(EMONO));
+}
+
+#[test]
+fn test_non_monotonic() {
+    let up_down = FanspeedCurve::new(vec![(0, 0), (50, 20), (100, 10)]);
+
+    assert_eq!(up_down.err(), Some(EMONO));
+}
+
+#[test]
+fn test_single_slope() {
+    let single_slope = FanspeedCurve::new(vec![(5, 0), (105, 20),]).unwrap();
+
+    assert_eq!(single_slope.speed_y(0), None);
+    assert_eq!(single_slope.speed_y(3), None);
+    assert_eq!(single_slope.speed_y(5 + 0), Some(0));
+    assert_eq!(single_slope.speed_y(5 + 25), Some(5));
+    assert_eq!(single_slope.speed_y(5 + 50), Some(10));
+    assert_eq!(single_slope.speed_y(5 + 75), Some(15));
+    assert_eq!(single_slope.speed_y(5 + 100), Some(20));
+    assert_eq!(single_slope.speed_y(5 + 101), Some(20));
+    assert_eq!(single_slope.speed_y(10101), Some(20));
+
+    assert_eq!(single_slope.temp_x(0), Some(5 + 0));
+    assert_eq!(single_slope.temp_x(5), Some(5 + 25));
+    assert_eq!(single_slope.temp_x(10), Some(5 + 50));
+    assert_eq!(single_slope.temp_x(15), Some(5 + 75));
+    assert_eq!(single_slope.temp_x(20), Some(5 + 100));
+    assert_eq!(single_slope.temp_x(21), None);
+
+    assert_eq!(single_slope.minspeed(), 0);
+}
+
+#[test]
+fn test_multiple_values() {
+    let multiple = FanspeedCurve::new(vec![(0, 1), (5, 10), (10, 60)]).unwrap();
+
+    assert_eq!(multiple.speed_y(0), Some(1));
+    assert_eq!(multiple.speed_y(5), Some(10));
+    assert_eq!(multiple.speed_y(10), Some(60));
+    assert_eq!(multiple.speed_y(11), Some(60));
+    assert_eq!(multiple.speed_y(101), Some(60));
+
+    assert_eq!(multiple.temp_x(0), None);
+    assert_eq!(multiple.temp_x(1), Some(0));
+    assert_eq!(multiple.temp_x(10), Some(5));
+    assert_eq!(multiple.temp_x(20), Some(6));
+    assert_eq!(multiple.temp_x(50), Some(9));
+    assert_eq!(multiple.temp_x(60), Some(10));
+    assert_eq!(multiple.temp_x(61), None);
+
+    assert_eq!(multiple.minspeed(), 1);
+}
+
+#[test]
+fn test_horizontal() {
+    let horizon = FanspeedCurve::new(vec![(20, 35), (22, 35), (25, 35), (60, 35)]);
+
+    assert!(horizon.is_ok());
+    let horizon = horizon.unwrap();
+
+    assert_eq!(horizon.speed_y(19), None);
+    assert_eq!(horizon.speed_y(20), Some(35));
+    assert_eq!(horizon.speed_y(21), Some(35));
+    assert_eq!(horizon.speed_y(59), Some(35));
+    assert_eq!(horizon.speed_y(60), Some(35));
+    assert_eq!(horizon.speed_y(61), Some(35));
+
+    assert_eq!(horizon.temp_x(34), None);
+    assert_eq!(horizon.temp_x(35), Some(60));
+    assert_eq!(horizon.temp_x(36), None);
+}
+
+#[test]
+fn test_vertical() {
+    let vertical = FanspeedCurve::new(vec![(20, 5), (20, 10), (20, 50), (20, 55)]);
+
+    assert!(vertical.is_ok());
+    let vertical = vertical.unwrap();
+
+    assert_eq!(vertical.speed_y(19), None);
+    assert_eq!(vertical.speed_y(20), Some(55));
+    assert_eq!(vertical.speed_y(21), Some(55));
+
+     assert_eq!(vertical.temp_x(4), None);
+     assert_eq!(vertical.temp_x(5), Some(20));
+     assert_eq!(vertical.temp_x(6), Some(20));
+     assert_eq!(vertical.temp_x(54), Some(20));
+     assert_eq!(vertical.temp_x(55), Some(20));
+     assert_eq!(vertical.temp_x(56), None);
+}
+
+
+#[test]
+fn test_plateau_values() {
+    let plateau = FanspeedCurve::new(vec![(0, 0), (10, 50), (20, 50), (30, 100)]);
+
+    assert!(plateau.is_ok());
+    let plateau = plateau.unwrap();
+
+    assert_eq!(plateau.speed_y(10), Some(50));
+    assert_eq!(plateau.speed_y(15), Some(50));
+    assert_eq!(plateau.speed_y(20), Some(50));
+
+    assert_eq!(plateau.temp_x(50), Some(20));
+}
+
+#[test]
+fn test_cliff_values() {
+    let cliff = FanspeedCurve::new(vec![(5, 5), (10, 20),  (10, 40), (10, 50), (30, 90)]);
+
+    assert!(cliff.is_ok());
+    let cliff = cliff.unwrap();
+
+    assert_eq!(cliff.speed_y(4), None);
+    assert_eq!(cliff.speed_y(10), Some(50));
+    assert_eq!(cliff.speed_y(30), Some(90));
+    assert_eq!(cliff.speed_y(31), Some(90));
+
+    assert_eq!(cliff.temp_x(20), Some(10));
+    assert_eq!(cliff.temp_x(43), Some(10));
+    assert_eq!(cliff.temp_x(50), Some(10));
+    assert_eq!(cliff.temp_x(90), Some(30));
+}
+
+#[test]
+fn test_stairs() {
+    let stairs = FanspeedCurve::new(
+        vec![(10, 1), (10, 5), (10, 10), (20, 10), (20, 20), (30, 20), (30, 30), (30, 40)]);
+
+    assert!(stairs.is_ok());
+    let stairs = stairs.unwrap();
+
+    assert_eq!(stairs.speed_y(30), Some(40));
+
+    assert_eq!(stairs.speed_y(9), None);
+    assert_eq!(stairs.speed_y(10), Some(10));
+    assert_eq!(stairs.speed_y(11), Some(10));
+    assert_eq!(stairs.speed_y(19), Some(10));
+    assert_eq!(stairs.speed_y(20), Some(20));
+    assert_eq!(stairs.speed_y(20), Some(20));
+    assert_eq!(stairs.speed_y(21), Some(20));
+    assert_eq!(stairs.speed_y(29), Some(20));
+    assert_eq!(stairs.speed_y(31), Some(40));
+    assert_eq!(stairs.speed_y(60), Some(40));
+}
+

--- a/src/fanspeedcurve.rs
+++ b/src/fanspeedcurve.rs
@@ -68,10 +68,6 @@ impl FanspeedCurve {
                 let dx = p1.0 - p0.0;
                 let dy = p1.1 - p0.1;
 
-                if dx == 0 {
-                   unreachable!();
-                }
-
                 let slope = (dy as f32) / (dx as f32);
 
                 let speed_y = (p0.1 as f32) + (((temp_x - p0.0) as f32) * slope);
@@ -98,10 +94,6 @@ impl FanspeedCurve {
             if speed_y >= p0.1 && speed_y <= p1.1 {
                 let dx = p1.0 - p0.0;
                 let dy = p1.1 - p0.1;
-
-                if dy == 0 {
-                   unreachable!();
-                }
 
                 let slope = (dx as f32) / (dy as f32);
 


### PR DESCRIPTION
The fans of some GPUs start to rapidly turn on and off at low speeds [1],
sometimes called "fan flickering".

One workaround is to only gradually lower the fan speed when in the
range where this happens. Raising also happens slower, but this
does not prevent this issue as reliably. Therefore flickering is also
detected: then the speed is increased back out of the flicker zone before
lowering it again.

The range is defined as a speed% where the flickering starts, and below that
a minimum speed% down to where the fan can be carefully lowered: [min, start].
Going lower than `min` means flickering happens all the time, but above `start`
arbitrary jumps cause no problems.

The zone range can be set via a config file option `fanflicker = [min, start]`
or on the command line via `-r, --fanflicker`. These are specified in %.
The command line overrides the config file, `-r 0` turn this feature off.

This also means the fan will always spin with at least `min` speed and will
not turn off completely. Also since up to `start` the fans might take some time
to reach the given speed, the corresponding temperature must not exceed 75°C.

E.g. `fanflicker = [11, 38]` means when going below 11% the fan always
flickers but behaves normally at 38%. So between these values speed changes
are applied gradually, currently -1 or +2 every 2 seconds.

1: https://forums.guru3d.com/threads/rtx-series-low-fan-speed-revving-noise-and-turn-on-off-problem.423708/
   http://forum.gigabyte.us/thread/5546/rtx2070-windforce-fan-flickering-issue
   https://www.techpowerup.com/forums/threads/gpu-fan-spins-up-and-down-when-idle.219471/
