### PR TITLE
Fix parsing error when driver version contains more than one dot.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 toml = "0.5"
 dirs = "*"
+regex = "1"
 
 [target.'cfg(unix)'.dependencies]
 nix = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,9 @@ use log::{Log, Record, LevelFilter, Metadata};
 extern crate getopts;
 use getopts::Options;
 
+extern crate regex;
+use regex::Regex;
+
 #[cfg(windows)] extern crate ctrlc;
 #[cfg(unix)] extern crate nix;
 #[cfg(unix)] use nix::sys::signal;
@@ -97,7 +100,7 @@ impl NVFanManager {
         let gpu_count = ctrl.gpu_count()?;
         let version: f32 = match ctrl.get_version() {
             Ok(v) => {
-                v.parse::<f32>().unwrap()
+                Regex::new(r"^(?P<a>\d+)\.(?P<i>\d+)\..*$").unwrap().replace(&v, "$a.$i").parse::<f32>().unwrap()
             }
             Err(e) => {
                 return Err(format!("Could not get driver version: {}", e))
@@ -650,8 +653,8 @@ pub fn main() {
         }
     };
 
-    info!("NVIDIA driver version: {:.2}",
-          mgr.ctrl.get_version().unwrap().parse::<f32>().unwrap());
+    info!("NVIDIA driver version: {}",
+          mgr.ctrl.get_version().unwrap());
     let gpu_count = mgr.ctrl.gpu_count().unwrap();
     for i in 0u32..gpu_count {
         info!("NVIDIA graphics adapter #{}: {}", i,


### PR DESCRIPTION
The Nvidia Vulkan beta drivers have more than two groups of digits.
This PR fixes parsing errors with these driver versions by discarding the second dot and everything after when detecting the version, and just using it verbatim instead of parsing it when logging the version.